### PR TITLE
[前端] 步骤3: 对接后端 /api/agents/status 接口

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,30 +1,21 @@
 <script setup lang="ts">
-import HelloWorld from './components/HelloWorld.vue'
+import AgentsStatus from './components/AgentsStatus.vue'
 </script>
 
 <template>
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://vuejs.org/" target="_blank">
-      <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
-    </a>
+  <div class="min-h-screen bg-gray-100">
+    <header class="bg-white shadow">
+      <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+        <h1 class="text-3xl font-bold text-gray-900">
+          📊 Agent 监控系统
+        </h1>
+      </div>
+    </header>
+    
+    <main class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+      <div class="px-4 py-6 sm:px-0">
+        <AgentsStatus />
+      </div>
+    </main>
   </div>
-  <HelloWorld msg="Vite + Vue" />
 </template>
-
-<style scoped>
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #42b883aa);
-}
-</style>

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -1,0 +1,17 @@
+import type { AgentsStatusResponse } from '../types/agent'
+
+// API 基础 URL - 可以通过环境变量配置
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api'
+
+/**
+ * 获取 Agent 状态列表
+ */
+export async function fetchAgentsStatus(): Promise<AgentsStatusResponse> {
+  const response = await fetch(`${API_BASE_URL}/agents/status`)
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch agents status: ${response.statusText}`)
+  }
+  
+  return response.json()
+}

--- a/frontend/src/components/AgentsStatus.vue
+++ b/frontend/src/components/AgentsStatus.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { fetchAgentsStatus } from '../api/agents'
+import type { Agent } from '../types/agent'
+
+const agents = ref<Agent[]>([])
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+// 定时刷新间隔（毫秒）
+const REFRESH_INTERVAL = 30000 // 30秒
+let timer: ReturnType<typeof setInterval> | null = null
+
+async function loadAgentsStatus() {
+  try {
+    loading.value = true
+    error.value = null
+    const data = await fetchAgentsStatus()
+    agents.value = data.agents
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load agents status'
+    console.error('Failed to fetch agents status:', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatLastActive(timestamp: number): string {
+  const date = new Date(timestamp)
+  return date.toLocaleTimeString('zh-CN', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  })
+}
+
+onMounted(() => {
+  loadAgentsStatus()
+  // 设置定时刷新
+  timer = setInterval(loadAgentsStatus, REFRESH_INTERVAL)
+})
+
+onUnmounted(() => {
+  if (timer) {
+    clearInterval(timer)
+  }
+})
+</script>
+
+<template>
+  <div class="agents-status">
+    <h2 class="text-xl font-bold mb-4">🤖 Agent 状态</h2>
+    
+    <div v-if="loading && agents.length === 0" class="text-gray-500">
+      加载中...
+    </div>
+    
+    <div v-else-if="error" class="text-red-500">
+      {{ error }}
+    </div>
+    
+    <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div 
+        v-for="agent in agents" 
+        :key="agent.id"
+        class="border rounded-lg p-4 shadow-sm"
+        :class="agent.isOnline ? 'border-green-500 bg-green-50' : 'border-gray-300 bg-gray-50'"
+      >
+        <div class="flex items-center justify-between mb-2">
+          <span class="font-semibold">{{ agent.name }}</span>
+          <span 
+            class="px-2 py-1 text-xs rounded-full"
+            :class="agent.isOnline ? 'bg-green-500 text-white' : 'bg-gray-400 text-white'"
+          >
+            {{ agent.isOnline ? '🟢 在线' : '⚪ 离线' }}
+          </span>
+        </div>
+        <div class="text-sm text-gray-600">
+          <p>ID: {{ agent.id }}</p>
+          <p>模型: {{ agent.model }}</p>
+          <p>最后活跃: {{ formatLastActive(agent.lastActive) }}</p>
+        </div>
+      </div>
+    </div>
+    
+    <div v-if="!loading && agents.length > 0" class="mt-4 text-sm text-gray-500">
+      <button @click="loadAgentsStatus" class="text-blue-500 hover:underline">
+        🔄 刷新
+      </button>
+    </div>
+  </div>
+</template>

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -1,0 +1,13 @@
+// Agent 状态类型定义
+
+export interface Agent {
+  id: string
+  name: string
+  model: string
+  lastActive: number
+  isOnline: boolean
+}
+
+export interface AgentsStatusResponse {
+  agents: Agent[]
+}


### PR DESCRIPTION
## 任务
完成 Issue #10：调用后端 /api/agents/status 接口

## 实现内容
- 添加 Agent 状态类型定义 ()
- 创建 API 服务层  ()
- 创建 AgentsStatus 组件展示 Agent 在线状态 ()
- 支持定时刷新（30秒）
- 更新 App.vue 使用新组件

## 测试
- 前端开发服务器运行后可以看到 Agent 状态卡片
- 需要后端提供 /api/agents/status 接口才能正常获取数据

## 备注
后端需要先实现 /api/agents/status 接口，前端才能正常调用。