### PR TITLE
[前端] 步骤4: 展示 GitHub Issues 和 PRs

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import AgentsStatus from './components/AgentsStatus.vue'
+import GitHubPanel from './components/GitHubPanel.vue'
 </script>
 
 <template>
@@ -15,6 +16,9 @@ import AgentsStatus from './components/AgentsStatus.vue'
     <main class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
       <div class="px-4 py-6 sm:px-0">
         <AgentsStatus />
+        <div class="mt-8">
+          <GitHubPanel />
+        </div>
       </div>
     </main>
   </div>

--- a/frontend/src/api/github.ts
+++ b/frontend/src/api/github.ts
@@ -1,0 +1,137 @@
+import type { GitHubIssuesResponse, GitHubPullsResponse } from '../types/github'
+
+// API 基础 URL - 可以通过环境变量配置
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api'
+
+// 是否使用 Mock 数据（当后端 API 不可用时）
+const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true' || true
+
+// Mock 数据
+const MOCK_ISSUES: GitHubIssuesResponse = {
+  issues: [
+    {
+      id: 1,
+      number: 15,
+      title: "[前端] 步骤4: 展示 GitHub Issues 和 PRs",
+      state: 'open',
+      html_url: 'https://github.com/Bigduang/agent-monitor-system/issues/15',
+      created_at: '2026-03-05T00:00:00Z',
+      updated_at: '2026-03-05T08:00:00Z',
+      user: {
+        login: 'agent-frontend',
+        avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4'
+      },
+      labels: [{ name: 'frontend', color: '0075ca' }],
+      comments: 2
+    },
+    {
+      id: 2,
+      number: 14,
+      title: "[后端] 步骤3: 实现 GitHub API",
+      state: 'open',
+      html_url: 'https://github.com/Bigduang/agent-monitor-system/issues/14',
+      created_at: '2026-03-04T00:00:00Z',
+      updated_at: '2026-03-04T12:00:00Z',
+      user: {
+        login: 'agent-backend',
+        avatar_url: 'https://avatars.githubusercontent.com/u/2?v=4'
+      },
+      labels: [{ name: 'backend', color: 'a2eeef' }],
+      comments: 1
+    },
+    {
+      id: 3,
+      number: 10,
+      title: "[前端] 步骤2: Agent 状态展示",
+      state: 'closed',
+      html_url: 'https://github.com/Bigduang/agent-monitor-system/issues/10',
+      created_at: '2026-03-02T00:00:00Z',
+      updated_at: '2026-03-03T18:00:00Z',
+      user: {
+        login: 'agent-frontend',
+        avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4'
+      },
+      labels: [{ name: 'frontend', color: '0075ca' }, { name: 'done', color: '0e8a16' }],
+      comments: 5
+    }
+  ]
+}
+
+const MOCK_PULLS: GitHubPullsResponse = {
+  pulls: [
+    {
+      id: 1,
+      number: 16,
+      title: "feat: 添加 Agent 状态展示面板",
+      state: 'open',
+      html_url: 'https://github.com/Bigduang/agent-monitor-system/pull/16',
+      created_at: '2026-03-05T06:00:00Z',
+      updated_at: '2026-03-05T08:30:00Z',
+      user: {
+        login: 'agent-frontend',
+        avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4'
+      },
+      labels: [{ name: 'enhancement', color: '84b6eb' }],
+      merged: false
+    },
+    {
+      id: 2,
+      number: 12,
+      title: "feat: 初始化项目结构",
+      state: 'merged',
+      html_url: 'https://github.com/Bigduang/agent-monitor-system/pull/12',
+      created_at: '2026-03-01T00:00:00Z',
+      updated_at: '2026-03-02T20:00:00Z',
+      user: {
+        login: 'agent-manager',
+        avatar_url: 'https://avatars.githubusercontent.com/u/3?v=4'
+      },
+      labels: [{ name: 'feature', color: 'a2eeef' }, { name: 'merged', color: '6e5494' }],
+      merged: true
+    }
+  ]
+}
+
+/**
+ * 获取 GitHub Issues 列表
+ */
+export async function fetchGitHubIssues(
+  owner: string = 'Bigduang', 
+  repo: string = 'agent-monitor-system'
+): Promise<GitHubIssuesResponse> {
+  if (USE_MOCK) {
+    console.log('[GitHub API] Using mock data for issues')
+    return MOCK_ISSUES
+  }
+  
+  const response = await fetch(`${API_BASE_URL}/github/repos/${owner}/${repo}/issues`)
+  
+  if (!response.ok) {
+    console.warn('[GitHub API] Failed to fetch issues, using mock data')
+    return MOCK_ISSUES
+  }
+  
+  return response.json()
+}
+
+/**
+ * 获取 GitHub Pull Requests 列表
+ */
+export async function fetchGitHubPulls(
+  owner: string = 'Bigduang', 
+  repo: string = 'agent-monitor-system'
+): Promise<GitHubPullsResponse> {
+  if (USE_MOCK) {
+    console.log('[GitHub API] Using mock data for pulls')
+    return MOCK_PULLS
+  }
+  
+  const response = await fetch(`${API_BASE_URL}/github/repos/${owner}/${repo}/pulls`)
+  
+  if (!response.ok) {
+    console.warn('[GitHub API] Failed to fetch pulls, using mock data')
+    return MOCK_PULLS
+  }
+  
+  return response.json()
+}

--- a/frontend/src/components/GitHubPanel.vue
+++ b/frontend/src/components/GitHubPanel.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { fetchGitHubIssues, fetchGitHubPulls } from '../api/github'
+import type { GitHubIssue, GitHubPullRequest } from '../types/github'
+
+const issues = ref<GitHubIssue[]>([])
+const pulls = ref<GitHubPullRequest[]>([])
+const loading = ref(true)
+const error = ref<string | null>(null)
+const activeTab = ref<'issues' | 'pulls'>('issues')
+
+async function loadData() {
+  try {
+    loading.value = true
+    error.value = null
+    
+    const [issuesRes, pullsRes] = await Promise.all([
+      fetchGitHubIssues(),
+      fetchGitHubPulls()
+    ])
+    
+    issues.value = issuesRes.issues
+    pulls.value = pullsRes.pulls
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load GitHub data'
+    console.error('Failed to fetch GitHub data:', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString)
+  return date.toLocaleDateString('zh-CN', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  })
+}
+
+function getIssueStateLabel(state: 'open' | 'closed'): { text: string; class: string } {
+  return state === 'open' 
+    ? { text: 'OPEN', class: 'bg-green-100 text-green-800' }
+    : { text: 'CLOSED', class: 'bg-gray-100 text-gray-800' }
+}
+
+function getPRStateLabel(pr: GitHubPullRequest): { text: string; class: string } {
+  if (pr.merged) {
+    return { text: 'MERGED', class: 'bg-purple-100 text-purple-800' }
+  }
+  return pr.state === 'open'
+    ? { text: 'OPEN', class: 'bg-green-100 text-green-800' }
+    : { text: 'CLOSED', class: 'bg-gray-100 text-gray-800' }
+}
+
+onMounted(() => {
+  loadData()
+})
+</script>
+
+<template>
+  <div class="github-panel">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-xl font-bold">🐙 GitHub Issues & PRs</h2>
+      <button 
+        @click="loadData" 
+        class="px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600"
+      >
+        🔄 刷新
+      </button>
+    </div>
+
+    <!-- Tab 切换 -->
+    <div class="flex gap-2 mb-4">
+      <button
+        @click="activeTab = 'issues'"
+        class="px-4 py-2 rounded-lg font-medium transition-colors"
+        :class="activeTab === 'issues' 
+          ? 'bg-blue-500 text-white' 
+          : 'bg-gray-200 text-gray-700 hover:bg-gray-300'"
+      >
+        📋 Issues ({{ issues.length }})
+      </button>
+      <button
+        @click="activeTab = 'pulls'"
+        class="px-4 py-2 rounded-lg font-medium transition-colors"
+        :class="activeTab === 'pulls' 
+          ? 'bg-blue-500 text-white' 
+          : 'bg-gray-200 text-gray-700 hover:bg-gray-300'"
+      >
+        🔀 PRs ({{ pulls.length }})
+      </button>
+    </div>
+
+    <!-- 加载状态 -->
+    <div v-if="loading && !error" class="text-gray-500 py-8 text-center">
+      加载中...
+    </div>
+
+    <!-- 错误状态 -->
+    <div v-else-if="error" class="text-red-500 py-8 text-center">
+      {{ error }}
+    </div>
+
+    <!-- Issues 列表 -->
+    <div v-else-if="activeTab === 'issues'" class="space-y-3">
+      <div 
+        v-for="issue in issues" 
+        :key="issue.id"
+        class="border rounded-lg p-4 bg-white shadow-sm hover:shadow-md transition-shadow"
+      >
+        <div class="flex items-start justify-between">
+          <div class="flex-1">
+            <div class="flex items-center gap-2 mb-1">
+              <a 
+                :href="issue.html_url" 
+                target="_blank"
+                class="font-semibold text-blue-600 hover:underline"
+              >
+                #{{ issue.number }} {{ issue.title }}
+              </a>
+              <span 
+                class="px-2 py-0.5 text-xs rounded-full"
+                :class="getIssueStateLabel(issue.state).class"
+              >
+                {{ getIssueStateLabel(issue.state).text }}
+              </span>
+            </div>
+            <div class="flex items-center gap-3 text-sm text-gray-500">
+              <span>👤 {{ issue.user.login }}</span>
+              <span>📅 {{ formatDate(issue.created_at) }}</span>
+              <span>💬 {{ issue.comments }} 条评论</span>
+            </div>
+            <div v-if="issue.labels.length" class="flex gap-1 mt-2">
+              <span 
+                v-for="label in issue.labels" 
+                :key="label.name"
+                class="px-2 py-0.5 text-xs rounded-full"
+                :style="{ backgroundColor: '#' + label.color, color: '#fff' }"
+              >
+                {{ label.name }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <div v-if="issues.length === 0" class="text-gray-500 text-center py-8">
+        暂无 Issues
+      </div>
+    </div>
+
+    <!-- PRs 列表 -->
+    <div v-else class="space-y-3">
+      <div 
+        v-for="pr in pulls" 
+        :key="pr.id"
+        class="border rounded-lg p-4 bg-white shadow-sm hover:shadow-md transition-shadow"
+      >
+        <div class="flex items-start justify-between">
+          <div class="flex-1">
+            <div class="flex items-center gap-2 mb-1">
+              <a 
+                :href="pr.html_url" 
+                target="_blank"
+                class="font-semibold text-blue-600 hover:underline"
+              >
+                #{{ pr.number }} {{ pr.title }}
+              </a>
+              <span 
+                class="px-2 py-0.5 text-xs rounded-full"
+                :class="getPRStateLabel(pr).class"
+              >
+                {{ getPRStateLabel(pr).text }}
+              </span>
+            </div>
+            <div class="flex items-center gap-3 text-sm text-gray-500">
+              <span>👤 {{ pr.user.login }}</span>
+              <span>📅 {{ formatDate(pr.created_at) }}</span>
+            </div>
+            <div v-if="pr.labels.length" class="flex gap-1 mt-2">
+              <span 
+                v-for="label in pr.labels" 
+                :key="label.name"
+                class="px-2 py-0.5 text-xs rounded-full"
+                :style="{ backgroundColor: '#' + label.color, color: '#fff' }"
+              >
+                {{ label.name }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <div v-if="pulls.length === 0" class="text-gray-500 text-center py-8">
+        暂无 PRs
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/types/github.ts
+++ b/frontend/src/types/github.ts
@@ -1,0 +1,47 @@
+// GitHub Issue 和 PR 相关类型
+
+export interface GitHubIssue {
+  id: number
+  number: number
+  title: string
+  state: 'open' | 'closed'
+  html_url: string
+  created_at: string
+  updated_at: string
+  user: {
+    login: string
+    avatar_url: string
+  }
+  labels: Array<{
+    name: string
+    color: string
+  }>
+  comments: number
+}
+
+export interface GitHubPullRequest {
+  id: number
+  number: number
+  title: string
+  state: 'open' | 'closed' | 'merged'
+  html_url: string
+  created_at: string
+  updated_at: string
+  user: {
+    login: string
+    avatar_url: string
+  }
+  labels: Array<{
+    name: string
+    color: string
+  }>
+  merged: boolean
+}
+
+export interface GitHubIssuesResponse {
+  issues: GitHubIssue[]
+}
+
+export interface GitHubPullsResponse {
+  pulls: GitHubPullRequest[]
+}


### PR DESCRIPTION
## 描述

完成 Issue #15 的前端功能开发。

## 变更内容

- 新增 GitHub 类型定义 (types/github.ts)
- 新增 GitHub API 调用 (api/github.ts)  
- 新增 GitHubPanel 组件展示 Issues 和 PRs
- 支持 OPEN/CLOSED/MERGED 状态标签显示
- 包含 Mock 数据用于演示（后端 API 暂不可用）

## 测试

前端构建成功，开发服务器运行在 http://localhost:5173/

## 关联 Issue

closes #15