### PR TITLE
[后端] Issue #28 - GitHub API 路径修复

### DIFF
--- a/backend/app/Http/Controllers/GitHubController.php
+++ b/backend/app/Http/Controllers/GitHubController.php
@@ -109,4 +109,22 @@ class GitHubController extends Controller
         
         return response()->json($result['data']);
     }
+    
+    /**
+     * 兼容路由：获取默认仓库的 Issue 列表
+     * GET /api/github/issues
+     */
+    public function getIssuesCompat(string $state = 'open'): JsonResponse
+    {
+        return $this->getIssues('Bigduang', 'agent-monitor-system', $state);
+    }
+    
+    /**
+     * 兼容路由：获取默认仓库的 PR 列表
+     * GET /api/github/pulls
+     */
+    public function getPullsCompat(string $state = 'open'): JsonResponse
+    {
+        return $this->getPulls('Bigduang', 'agent-monitor-system', $state);
+    }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -15,6 +15,10 @@ Route::get('/agents/status', [AgentController::class, 'status']);
 
 // GitHub 集成
 
+// 兼容路由：前端调用习惯
+Route::get('/github/issues', [GitHubController::class, 'getIssuesCompat']);
+Route::get('/github/pulls', [GitHubController::class, 'getPullsCompat']);
+
 Route::prefix('github')->group(function () {
     // 获取仓库信息
     Route::get('/repos/{owner}/{repo}', [GitHubController::class, 'getRepo']);


### PR DESCRIPTION
## 描述
修复 GitHub API 路径不符合前端调用习惯的问题。

## 变更内容
- 添加 GET /api/github/issues -> 返回 Bigduang/agent-monitor-system 的 issues
- 添加 GET /api/github/pulls -> 返回 Bigduang/agent-monitor-system 的 pulls

## 测试
已通过 curl 测试 API 正常工作：
- /api/github/issues 返回 issues 列表
- /api/github/pulls 返回 pulls 列表（当前为空）

## 关联 Issue
Closes #28