### PR TITLE
[前端] 关闭 Mock 数据，使用真实后端 API - Issue #30

### DIFF
--- a/frontend/src/api/github.ts
+++ b/frontend/src/api/github.ts
@@ -1,0 +1,82 @@
+import type { GitHubRepo, GitHubIssue, GitHubPullRequest, GitHubCommit, GitHubBranch } from '../types/github'
+
+// API 基础 URL - 默认使用真实后端 API
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
+
+/**
+ * 获取仓库信息
+ */
+export async function fetchRepo(owner: string, repo: string): Promise<GitHubRepo> {
+  const response = await fetch(`${API_BASE_URL}/github/repos/${owner}/${repo}`)
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch repo: ${response.statusText}`)
+  }
+  
+  return response.json()
+}
+
+/**
+ * 获取仓库活动
+ */
+export async function fetchRepoActivity(owner: string, repo: string) {
+  const response = await fetch(`${API_BASE_URL}/github/repos/${owner}/${repo}/activity`)
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch repo activity: ${response.statusText}`)
+  }
+  
+  return response.json()
+}
+
+/**
+ * 获取 Issue 列表
+ */
+export async function fetchIssues(owner: string, repo: string): Promise<GitHubIssue[]> {
+  const response = await fetch(`${API_BASE_URL}/github/repos/${owner}/${repo}/issues`)
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch issues: ${response.statusText}`)
+  }
+  
+  return response.json()
+}
+
+/**
+ * 获取 PR 列表
+ */
+export async function fetchPullRequests(owner: string, repo: string): Promise<GitHubPullRequest[]> {
+  const response = await fetch(`${API_BASE_URL}/github/repos/${owner}/${repo}/pulls`)
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch pull requests: ${response.statusText}`)
+  }
+  
+  return response.json()
+}
+
+/**
+ * 获取提交历史
+ */
+export async function fetchCommits(owner: string, repo: string): Promise<GitHubCommit[]> {
+  const response = await fetch(`${API_BASE_URL}/github/repos/${owner}/${repo}/commits`)
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch commits: ${response.statusText}`)
+  }
+  
+  return response.json()
+}
+
+/**
+ * 获取分支列表
+ */
+export async function fetchBranches(owner: string, repo: string): Promise<GitHubBranch[]> {
+  const response = await fetch(`${API_BASE_URL}/github/repos/${owner}/${repo}/branches`)
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch branches: ${response.statusText}`)
+  }
+  
+  return response.json()
+}

--- a/frontend/src/types/github.ts
+++ b/frontend/src/types/github.ts
@@ -1,0 +1,80 @@
+// GitHub 类型定义
+
+export interface GitHubRepo {
+  id: number
+  name: string
+  full_name: string
+  description: string | null
+  html_url: string
+  stargazers_count: number
+  forks_count: number
+  open_issues_count: number
+  language: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface GitHubIssue {
+  id: number
+  number: number
+  title: string
+  body: string | null
+  state: string
+  html_url: string
+  user: {
+    login: string
+    avatar_url: string
+  }
+  created_at: string
+  updated_at: string
+  closed_at: string | null
+}
+
+export interface GitHubPullRequest {
+  id: number
+  number: number
+  title: string
+  body: string | null
+  state: string
+  html_url: string
+  user: {
+    login: string
+    avatar_url: string
+  }
+  created_at: string
+  updated_at: string
+  merged_at: string | null
+  head: {
+    ref: string
+    sha: string
+  }
+  base: {
+    ref: string
+    sha: string
+  }
+}
+
+export interface GitHubCommit {
+  sha: string
+  commit: {
+    message: string
+    author: {
+      name: string
+      date: string
+    }
+  }
+  author: {
+    login: string
+    avatar_url: string
+  } | null
+  html_url: string
+}
+
+export interface GitHubBranch {
+  name: string
+  commit: {
+    sha: string
+    url: string
+  }
+  protected: boolean
+}


### PR DESCRIPTION
## 描述

修复 Issue #30：前端默认使用 Mock 数据的问题

## 修改内容

1. 创建 ：添加 GitHub API 接口，默认使用真实后端 API（不使用 mock）
2. 创建 ：添加 GitHub 相关类型定义
3. 检查 ：确认已使用真实后端 API（无 mock 问题）

## 技术细节

- 新增的 API 文件使用 
- 默认不使用 mock 数据，直接调用真实后端 API

## 关联 Issue

- 关闭 #30