### PR TITLE
[前端] 修复 API 调用 CORS 跨域问题 #35

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,2 @@
-# 生产环境 API 地址
-VITE_API_BASE_URL=http://localhost:8000/api
+# 生产环境 API 地址 - 使用相对路径避免跨域问题
+VITE_API_BASE_URL=/api


### PR DESCRIPTION
## 修复内容

修复 Issue #35：前端页面无法获取 GitHub 数据

### 问题
- 前端使用绝对路径 http://localhost:8000/api 调用 API，导致跨域问题
- 浏览器访问 192.168.8.96:8000/dashboard/ 时，请求 localhost:8000 被 CORS 阻止

### 解决方案
- 修改 frontend/.env.production，使用相对路径 /api 替代绝对路径
- 重新构建并部署到 backend/public/dashboard

### 自测结果
- 页面正常访问 http://192.168.8.96:8000/dashboard/
- Agent Status API 正常工作
- GitHub Issues 和 PRs 显示正常

关联 Issue #35