### PR TITLE
[后端] Issue #43 - Agent 列表添加 manager001

### DIFF
--- a/backend/app/Http/Controllers/AgentController.php
+++ b/backend/app/Http/Controllers/AgentController.php
@@ -33,6 +33,11 @@ class AgentController extends Controller
                     'id' => 'chief001',
                     'name' => '总工程师',
                     'role' => '总工程师'
+                ],
+                'manager001' => [
+                    'id' => 'manager001',
+                    'name' => '武藤彩香',
+                    'role' => '项目经理'
                 ]
             ];
             
@@ -119,6 +124,15 @@ class AgentController extends Controller
                         'id' => 'chief001',
                         'name' => '总工程师',
                         'role' => '总工程师',
+                        'model' => 'offline',
+                        'lastActive' => null,
+                        'isOnline' => false,
+                        'updatedAt' => null
+                    ],
+                    [
+                        'id' => 'manager001',
+                        'name' => '武藤彩香',
+                        'role' => '项目经理',
                         'model' => 'offline',
                         'lastActive' => null,
                         'isOnline' => false,


### PR DESCRIPTION
## 描述

修复 Issue #43：Agent Status API 只返回 3 个 agent，缺少 manager001

## 修改内容

在 agentMap 中添加 manager001 (武藤彩香, 项目经理)

## 提交记录

79f471d feat(backend): 添加 manager001 到 Agent 列表